### PR TITLE
Skip range check for totally uninitialized areas.

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -206,16 +206,16 @@ pub(crate) fn read_and_check_elf32_ph_entries(
                         file_offset += len;
                         remaining -= len;
                     }
-                }
-                if entry.memsz > entry.filez {
-                    // we have some uninitialized data too
-                    check_address_range(
-                        valid_ranges,
-                        entry.paddr + entry.filez,
-                        entry.vaddr + entry.filez,
-                        entry.memsz - entry.filez,
-                        true,
-                    )?;
+                    if entry.memsz > entry.filez {
+                        // we have some uninitialized data too
+                        check_address_range(
+                            valid_ranges,
+                            entry.paddr + entry.filez,
+                            entry.vaddr + entry.filez,
+                            entry.memsz - entry.filez,
+                            true,
+                        )?;
+                    }
                 }
             }
         }


### PR DESCRIPTION
I was attempting to reference address space sections in the USB DPSRAM
area on RP2040 using a modified linker script, and elf2uf2 was refusing
to load the binaries because of its address range checks. These checks
might make sense for Flash, but unless you're going to extend the valid
range table to describe every peripheral in the system, they do _not_
make sense for anything you could possibly reference with a linker.

The previous code _almost_ let these sections through except for the
uninitialized-tail check. This commit moves that to only apply to
partially initialized sections.

Fixes #11.