### PR TITLE
Split this crate into a binary and a library.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -173,7 +173,7 @@ checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
 name = "elf2uf2-rs"
-version = "1.3.7"
+version = "1.4.0-dev"
 dependencies = [
  "assert_into",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elf2uf2-rs"
-version = "1.3.7"
+version = "1.4.0-dev"
 authors = ["Jonathan Nilsson <jonathan@voysys.se>"]
 edition = "2018"
 
@@ -10,12 +10,21 @@ readme = "README.md"
 license = "0BSD"
 repository = "https://github.com/JoNil/elf2uf2-rs"
 
+[[bin]]
+name = "elf2uf2-rs"
+required-features = ["binary"]
+
+[features]
+default = ["binary"]
+binary = ["clap", "once_cell", "progress_bar", "serialport", "sysinfo"]
+progress_bar = ["pbr"]
+
 [dependencies]
-assert_into = "1.1"
-clap = { version = "3.0.0-rc.4", features = ["derive"] }
-once_cell = "1.5"
-pbr = "1"
-serialport = "4"
-static_assertions = "1"
-sysinfo = "0.20"
+assert_into = { version = "1.1" }
+clap = { version = "3.0.0-rc.4", features = ["derive"], optional = true }
+once_cell = { version = "1.5", optional = true }
+pbr = { version = "1", optional = true }
+serialport = { version = "4", optional = true }
+static_assertions = { version = "1" }
+sysinfo = { version = "0.20", optional = true }
 zerocopy = "0.6"

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Port of elf2uf2 to rust
 
+## Use as a Binary
 ```bash
 cargo install elf2uf2-rs
 ```
+
+## Use as a Library
+This can also be imported into your cargo managed project as a library.
+See the documentation for more information on that.
 
 ## Options
 -d automatic deployment to a mounted pico.
 -s open the pico as a serial device after deploy and print serial output.
 
-Original at https://github.com/raspberrypi/pico-sdk/tree/master/tools/elf2uf2
+Derived from original at https://github.com/raspberrypi/pico-sdk/tree/master/tools/elf2uf2

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,179 @@
+//! This is the backend library logic for elf2uf2-rs.
+//! If you wish to use it within your own tools,
+//! I recommend specifying "default-features = false"
+//! in your Cargo.toml.
+//!
+//! See the documentation of elf2uf2 for more details.
+
+use address_range::AddressRange;
+use assert_into::AssertInto;
+use elf::{read_and_check_elf32_ph_entries, realize_page};
+#[cfg(feature = "progress_bar")]
+use pbr::{ProgressBar, Units};
+use std::{
+    error::Error,
+    io::{Read, Seek, Write},
+};
+use uf2::{
+    Uf2BlockData, Uf2BlockFooter, Uf2BlockHeader, UF2_FLAG_FAMILY_ID_PRESENT, UF2_MAGIC_END,
+    UF2_MAGIC_START0, UF2_MAGIC_START1,
+};
+use zerocopy::AsBytes;
+
+// Consuming code needs the AddressRange type, and potentially some of the definitions.
+pub mod address_range;
+mod elf;
+mod uf2;
+// These are (potentially) needed by library consuming code, let's export them, w/o including the whole modules
+pub use elf::{Elf32Header, PAGE_SIZE};
+pub use uf2::RP2040_FAMILY_ID;
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+/// Set the level of verbosity of the elf2uf2 process
+pub enum Verbosity {
+    /// Print almost nothing to the console
+    Quiet,
+    /// Print a progress bar to the console
+    #[cfg(feature = "progress_bar")]
+    Progress,
+    /// Verbose mode, print everything, including page offsets
+    Verbose,
+}
+
+/// Convert the ELF file that backs the Read+Seek object provided into a UF2 bootloader file on the output Writer.
+///
+/// Currently only supports Little-Endian ARM32 objects as input, that do not use hard-float.
+/// Additionally, to use this, a few family speific options must be provided:
+/// - You must specify the family ID that shall be written to the UF2 file.
+///   We provide a definition for the Raspberry Pi RP2040, but other values are allowed.
+/// - A function that given the ELF Header, returns the valid address ranges that should be allowed.
+///   This could be used to support different types of memory spaces to be programmed.
+///   Again, we provide definitions for the RP2040 here.
+/// - A function that does any extra validation of the entry point, if needed.
+///
+/// # Examples
+/// ```
+/// crate::elf2uf2(
+///     std::fs::File::open(...).unwrap(),
+///     std::fs::File::create(...).unwrap(),
+///     Verbosity::Quiet,
+///     crate::RP2040_FAMILY_ID,
+///     |eh| {
+///         let ram_style = 0x2 == eh.entry >> 28;
+///         if ram_style {
+///             crate::address_range::RP2040_ADDRESS_RANGES_RAM
+///         } else {
+///             crate::address_range::RP2040_ADDRESS_RANGES_FLASH
+///         }
+///     },
+///     |eh, expected_ep| {
+///         let ram_style = 0x2 == eh.entry >> 28;
+///         if ram_style {
+///             if eh.entry != expected_ep {
+///                 return Err(format!(
+///                 "A RAM binary should have an entry point at the beginning: {:#08x} (not {:#08x})\n",
+///                 expected_ep, eh.entry as u32
+///             )
+///             .into());
+///             }
+///         }
+///         Ok(())
+///     },
+/// );
+/// ```
+pub fn elf2uf2(
+    mut input: impl Read + Seek,
+    mut output: impl Write,
+    verbosity: Verbosity,
+    family_id: u32,
+    validate_address_ranges: impl FnOnce(&elf::Elf32Header) -> &'static [AddressRange],
+    validate_entry_point: impl FnOnce(&elf::Elf32Header, u32) -> Result<(), Box<dyn Error>>,
+) -> Result<(), Box<dyn Error>> {
+    let eh = elf::read_and_check_elf32_header(&mut input)?;
+
+    let valid_ranges = validate_address_ranges(&eh);
+
+    let pages = read_and_check_elf32_ph_entries(
+        &mut input,
+        &eh,
+        valid_ranges,
+        verbosity == Verbosity::Verbose,
+    )?;
+
+    if pages.is_empty() {
+        return Err("The input file has no memory pages".into());
+    }
+    {
+        let expected_ep = pages.keys().next().unwrap() | 0x1;
+        validate_entry_point(&eh, expected_ep)?;
+    }
+
+    let mut block_header = Uf2BlockHeader {
+        magic_start0: UF2_MAGIC_START0,
+        magic_start1: UF2_MAGIC_START1,
+        flags: UF2_FLAG_FAMILY_ID_PRESENT,
+        target_addr: 0,
+        payload_size: PAGE_SIZE,
+        block_no: 0,
+        num_blocks: pages.len().assert_into(),
+        file_size: family_id,
+    };
+
+    let mut block_data: Uf2BlockData = [0; 476];
+
+    let block_footer = Uf2BlockFooter {
+        magic_end: UF2_MAGIC_END,
+    };
+
+    #[cfg(feature = "progress_bar")]
+    let mut pb = if verbosity == Verbosity::Progress {
+        Some(ProgressBar::new((pages.len() * 512).assert_into()))
+    } else {
+        None
+    };
+    #[cfg(feature = "progress_bar")]
+    if let Some(pb) = &mut pb {
+        pb.set_units(Units::Bytes);
+    }
+
+    let last_page_num = pages.len() - 1;
+
+    for (page_num, (target_addr, fragments)) in pages.into_iter().enumerate() {
+        block_header.target_addr = target_addr;
+        block_header.block_no = page_num.assert_into();
+
+        if verbosity == Verbosity::Verbose {
+            println!(
+                "Page {} / {} {:#08x}",
+                block_header.block_no as u32,
+                block_header.num_blocks as u32,
+                block_header.target_addr as u32
+            );
+        }
+
+        block_data.iter_mut().for_each(|v| *v = 0);
+
+        realize_page(&mut input, &fragments, &mut block_data)?;
+
+        output.write_all(block_header.as_bytes())?;
+        output.write_all(block_data.as_bytes())?;
+        output.write_all(block_footer.as_bytes())?;
+        output.flush()?;
+
+        if page_num != last_page_num {
+            #[cfg(feature = "progress_bar")]
+            if let Some(pb) = &mut pb {
+                pb.add(512);
+            }
+        }
+    }
+
+    // Drop the output before the progress bar is allowd to finish
+    drop(output);
+    #[cfg(feature = "progress_bar")]
+    if let Some(pb) = &mut pb {
+        pb.add(512);
+    }
+
+    Ok(())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,29 +1,19 @@
-use address_range::{MAIN_RAM_START, RP2040_ADDRESS_RANGES_FLASH, RP2040_ADDRESS_RANGES_RAM};
-use assert_into::AssertInto;
 use clap::Parser;
-use elf::{read_and_check_elf32_ph_entries, realize_page, PAGE_SIZE};
 use once_cell::sync::OnceCell;
-use pbr::{ProgressBar, Units};
 use serialport::FlowControl;
 use static_assertions::const_assert;
 use std::{
     error::Error,
     fs::{self, File},
-    io::{self, BufReader, Read, Seek, Write},
+    io::{self, BufReader, Read, Write},
     path::{Path, PathBuf},
     thread,
     time::Duration,
 };
 use sysinfo::{DiskExt, SystemExt};
-use uf2::{
-    Uf2BlockData, Uf2BlockFooter, Uf2BlockHeader, RP2040_FAMILY_ID, UF2_FLAG_FAMILY_ID_PRESENT,
-    UF2_MAGIC_END, UF2_MAGIC_START0, UF2_MAGIC_START1,
-};
-use zerocopy::AsBytes;
 
-mod address_range;
-mod elf;
-mod uf2;
+use elf2uf2_rs as lib;
+use lib::address_range::{MAIN_RAM_START, RP2040_ADDRESS_RANGES_FLASH, RP2040_ADDRESS_RANGES_RAM};
 
 #[derive(Parser, Debug)]
 #[clap(author = "Jonathan Nilsson")]
@@ -63,116 +53,6 @@ impl Opts {
 
 static OPTS: OnceCell<Opts> = OnceCell::new();
 
-fn elf2uf2(mut input: impl Read + Seek, mut output: impl Write) -> Result<(), Box<dyn Error>> {
-    let eh = elf::read_and_check_elf32_header(&mut input)?;
-
-    let ram_style = 0x2 == eh.entry >> 28;
-
-    if Opts::global().verbose {
-        if ram_style {
-            println!("Detected RAM binary");
-        } else {
-            println!("Detected FLASH binary");
-        }
-    }
-
-    let valid_ranges = if ram_style {
-        RP2040_ADDRESS_RANGES_RAM
-    } else {
-        RP2040_ADDRESS_RANGES_FLASH
-    };
-
-    let pages = read_and_check_elf32_ph_entries(&mut input, &eh, valid_ranges)?;
-
-    if pages.is_empty() {
-        return Err("The input file has no memory pages".into());
-    }
-
-    if ram_style {
-        let expected_ep = pages.keys().next().unwrap() | 0x1;
-        if eh.entry != expected_ep {
-            return Err(format!(
-                "A RAM binary should have an entry point at the beginning: {:#08x} (not {:#08x})\n",
-                expected_ep, eh.entry as u32
-            )
-            .into());
-        }
-        const_assert!(0 == (MAIN_RAM_START & (PAGE_SIZE - 1)));
-        // currently don't require this as entry point is now at the start, we don't know where reset vector is
-    }
-
-    let mut block_header = Uf2BlockHeader {
-        magic_start0: UF2_MAGIC_START0,
-        magic_start1: UF2_MAGIC_START1,
-        flags: UF2_FLAG_FAMILY_ID_PRESENT,
-        target_addr: 0,
-        payload_size: PAGE_SIZE,
-        block_no: 0,
-        num_blocks: pages.len().assert_into(),
-        file_size: RP2040_FAMILY_ID,
-    };
-
-    let mut block_data: Uf2BlockData = [0; 476];
-
-    let block_footer = Uf2BlockFooter {
-        magic_end: UF2_MAGIC_END,
-    };
-
-    if Opts::global().deploy {
-        println!("Transfering program to pico");
-    }
-
-    let mut pb = if !Opts::global().verbose && Opts::global().deploy {
-        Some(ProgressBar::new((pages.len() * 512).assert_into()))
-    } else {
-        None
-    };
-
-    if let Some(pb) = &mut pb {
-        pb.set_units(Units::Bytes);
-    }
-
-    let last_page_num = pages.len() - 1;
-
-    for (page_num, (target_addr, fragments)) in pages.into_iter().enumerate() {
-        block_header.target_addr = target_addr;
-        block_header.block_no = page_num.assert_into();
-
-        if Opts::global().verbose {
-            println!(
-                "Page {} / {} {:#08x}",
-                block_header.block_no as u32,
-                block_header.num_blocks as u32,
-                block_header.target_addr as u32
-            );
-        }
-
-        block_data.iter_mut().for_each(|v| *v = 0);
-
-        realize_page(&mut input, &fragments, &mut block_data)?;
-
-        output.write_all(block_header.as_bytes())?;
-        output.write_all(block_data.as_bytes())?;
-        output.write_all(block_footer.as_bytes())?;
-        output.flush()?;
-
-        if page_num != last_page_num {
-            if let Some(pb) = &mut pb {
-                pb.add(512);
-            }
-        }
-    }
-
-    // Drop the output before the progress bar is allowd to finish
-    drop(output);
-
-    if let Some(pb) = &mut pb {
-        pb.add(512);
-    }
-
-    Ok(())
-}
-
 fn main() -> Result<(), Box<dyn Error>> {
     OPTS.set(Opts::parse()).unwrap();
 
@@ -205,8 +85,53 @@ fn main() -> Result<(), Box<dyn Error>> {
         } else {
             File::create(Opts::global().output_path())?
         };
+        if Opts::global().deploy {
+            println!("Transfering program to pico");
+        }
+        let verbosity = match (Opts::global().verbose, Opts::global().deploy) {
+            #[cfg(feature = "progress_bar")]
+            (false, true) => lib::Verbosity::Progress,
+            (true, _) => lib::Verbosity::Verbose,
+            _ => lib::Verbosity::Quiet,
+        };
+        if let Err(err) = lib::elf2uf2(
+            input,
+            output,
+            verbosity,
+            lib::RP2040_FAMILY_ID,
+            |eh| {
+                let ram_style = 0x2 == eh.entry >> 28;
 
-        if let Err(err) = elf2uf2(input, output) {
+                if Opts::global().verbose {
+                    if ram_style {
+                        println!("Detected RAM binary");
+                    } else {
+                        println!("Detected FLASH binary");
+                    }
+                }
+
+                if ram_style {
+                    RP2040_ADDRESS_RANGES_RAM
+                } else {
+                    RP2040_ADDRESS_RANGES_FLASH
+                }
+            },
+            |eh, expected_ep| {
+                let ram_style = 0x2 == eh.entry >> 28;
+                if ram_style {
+                    if eh.entry != expected_ep {
+                        return Err(format!(
+                        "A RAM binary should have an entry point at the beginning: {:#08x} (not {:#08x})\n",
+                        expected_ep, eh.entry as u32
+                    )
+                    .into());
+                    }
+                    const_assert!(0 == (MAIN_RAM_START & (lib::PAGE_SIZE - 1)));
+                    // currently don't require this as entry point is now at the start, we don't know where reset vector is
+                }
+                Ok(())
+            },
+        ) {
             if Opts::global().deploy {
                 fs::remove_file(deployed_path.unwrap())?;
             } else {


### PR DESCRIPTION
This is motivated by my usecase, wherein I have a tool that needs to
convert elf to uf2, but does not want to call an external tool.
I figured that while I could just vendor the changed code, I'd try improving
it and upstream it, in the event there is anybody else who might benefit.

The main logic is unchanged, but I've factored the elf2uf2 function out of
main.rs and into lib.rs, as well as its dependencies. Additionally, I have
changed elf2uf2 such that the rp2040 is not hardcoded within the function.
While my application is for the RP2040 as well, I wanted to leave the code
being more general and able to support other families.
This all necessitated not only changing elf2uf2 and downstream functions
to not use the global options struct, but elf2uf2 now takes two closures
to determine chip and usecase specific logic.
The binary that was the original form of this crate still exists, and is
still the same tool, specialized for RP2040 use.

To support this split crate, a default, "binary" feature is provided
that enables all the features needed to make a usable binary.
However, with "default-features = false", this only requires
the minimal set of libraries.

At the current time, this library assumes that the ELF *MUST*
be an ARM32 Little Endian binary, that does not use hard float.
I'm not sure why the No Hard Float requirement exists in elf.rs,
but I've left it alone in case it's important.
However, I suspect that it should be removed (or put in the provided closure),
for broader compatibility with other targets.

Additionally, as I understand it, having a single crate with both
a (non-trivial) binary, as well as the library backing it is not
recommended, due to needing to play the games with cargo features.
However, as splitting into two crates is a greater logistical challenge,
I have not done that here. My testing shows the dependency graph
is appropriately pruned by not including the default features.