### PR TITLE
Always flush stdout to prevent buffering of data

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -250,7 +250,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                         let mut serial_buf = [0; 1024];
                         loop {
                             match port.read(&mut serial_buf) {
-                                Ok(t) => io::stdout().write_all(&serial_buf[..t])?,
+                                Ok(t) => {
+                                    io::stdout().write_all(&serial_buf[..t])?;
+                                    io::stdout().flush()?;
+                                }
                                 Err(ref e) if e.kind() == io::ErrorKind::TimedOut => (),
                                 Err(e) => return Err(e.into()),
                             }


### PR DESCRIPTION
Thanks for the cool crate :)

This prevents `stdout` from buffering data internally.

This is relevant when sending binary data (e.g. `defmt` logs) to `stdout`, as it will look for some marker to flush (usually ` \n`) which only semi-randomly appears. This causes the data to be buffered internally and flushed as a big block, instead of continually as it flows out of the device, making for a less-than-ideal logging experience.

Our use case is logging over USB with `defmt-bbq` for the [rusty-probe-firmware](https://github.com/probe-rs/rusty-probe-firmware).

