### PR TITLE
Add "serial" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,11 @@ assert_into = "1.1"
 clap = { version = "3.0.0-rc.4", features = ["derive"] }
 once_cell = "1.5"
 pbr = "1"
-serialport = "4"
+serialport = { version = "4", optional = true }
 static_assertions = "1"
 sysinfo = "0.28"
 zerocopy = "0.6"
+
+[features]
+default = ["serial"]
+serial = ["serialport"]


### PR DESCRIPTION
## Description
This PR add a new `serial` feature flag, which allows to disable `serialport` dependency.
By default this feature is enabled to preserve current user expirience.

## Motivation

I'm using `elf2uf2` in GitHub Actions for [building firmware releases](https://github.com/dotcypress/wzhooh/blob/main/.github/workflows/build.yml#L55).

It's hard to install current version to GitHub Actions runner because of [`serialport/libudev-sys` dependency](https://github.com/dotcypress/wzhooh/actions/runs/6103862462/job/16565002077#step:4:80)
