### PR TITLE
Use tests module for running tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -323,28 +323,34 @@ fn main() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-#[test]
-pub fn hello_usb() {
-    // Horrendous hack to get it to stop complaining about opts
-    // TODO: just pass opts by reference, or use log crate
-    OPTS.set(Default::default()).ok();
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io;
 
-    let bytes_in = io::Cursor::new(&include_bytes!("../hello_usb.elf")[..]);
-    let mut bytes_out = Vec::new();
-    elf2uf2(bytes_in, &mut bytes_out).unwrap();
+    #[test]
+    pub fn hello_usb() {
+        // Horrendous hack to get it to stop complaining about opts
+        // TODO: just pass opts by reference, or use log crate
+        OPTS.set(Default::default()).ok();
 
-    assert_eq!(bytes_out, include_bytes!("../hello_usb.uf2"));
-}
+        let bytes_in = io::Cursor::new(&include_bytes!("../hello_usb.elf")[..]);
+        let mut bytes_out = Vec::new();
+        elf2uf2(bytes_in, &mut bytes_out).unwrap();
 
-#[test]
-pub fn hello_serial() {
-    // Horrendous hack to get it to stop complaining about opts
-    // TODO: just pass opts by reference, or use log crate
-    OPTS.set(Default::default()).ok();
+        assert_eq!(bytes_out, include_bytes!("../hello_usb.uf2"));
+    }
 
-    let bytes_in = io::Cursor::new(&include_bytes!("../hello_serial.elf")[..]);
-    let mut bytes_out = Vec::new();
-    elf2uf2(bytes_in, &mut bytes_out).unwrap();
+    #[test]
+    pub fn hello_serial() {
+        // Horrendous hack to get it to stop complaining about opts
+        // TODO: just pass opts by reference, or use log crate
+        OPTS.set(Default::default()).ok();
 
-    assert_eq!(bytes_out, include_bytes!("../hello_serial.uf2"));
+        let bytes_in = io::Cursor::new(&include_bytes!("../hello_serial.elf")[..]);
+        let mut bytes_out = Vec::new();
+        elf2uf2(bytes_in, &mut bytes_out).unwrap();
+
+        assert_eq!(bytes_out, include_bytes!("../hello_serial.uf2"));
+    }
 }


### PR DESCRIPTION
Also fixes this error:

```
error[E0433]: failed to resolve: use of undeclared crate or module `io`
   --> src/main.rs:332:20
    |
332 |     let bytes_in = io::Cursor::new(&include_bytes!("../hello_usb.elf")[..]);
    |                    ^^ use of undeclared crate or module `io`
    |
help: consider importing one of these items
    |
1   + use std::collections::btree_map::Cursor;
    |
1   + use std::collections::linked_list::Cursor;
    |
1   + use std::io::Cursor;
    |
help: if you import `Cursor`, refer to it directly
    |
332 -     let bytes_in = io::Cursor::new(&include_bytes!("../hello_usb.elf")[..]);
332 +     let bytes_in = Cursor::new(&include_bytes!("../hello_usb.elf")[..]);
    |

error[E0433]: failed to resolve: use of undeclared crate or module `io`
   --> src/main.rs:345:20
    |
345 |     let bytes_in = io::Cursor::new(&include_bytes!("../hello_serial.elf")[..]);
    |                    ^^ use of undeclared crate or module `io`
    |
help: consider importing one of these items
    |
1   + use std::collections::btree_map::Cursor;
    |
1   + use std::collections::linked_list::Cursor;
    |
1   + use std::io::Cursor;
    |
help: if you import `Cursor`, refer to it directly
    |
345 -     let bytes_in = io::Cursor::new(&include_bytes!("../hello_serial.elf")[..]);
345 +     let bytes_in = Cursor::new(&include_bytes!("../hello_serial.elf")[..]);
    |

For more information about this error, try `rustc --explain E0433`.
error: could not compile `elf2uf2-rs` (bin "elf2uf2-rs" test) due to 2 previous errors
```
