### PR TITLE
Add special check for ChromeOS's mountpoint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -241,13 +241,17 @@ fn main() -> Result<(), Box<dyn Error>> {
         let disks = Disks::new_with_refreshed_list();
 
         let mut pico_drive = None;
-        for disk in &disks {
-            let mount = disk.mount_point();
+        if Path::new(r"/mnt/chromeos/removable/RPI-RP2").is_dir() {
+            pico_drive = Some(PathBuf::from(r"/mnt/chromeos/removable/RPI-RP2"));
+        } else {
+            for disk in &disks {
+                let mount = disk.mount_point();
 
-            if mount.join("INFO_UF2.TXT").is_file() {
-                println!("Found pico uf2 disk {}", &mount.to_string_lossy());
-                pico_drive = Some(mount.to_owned());
-                break;
+                if mount.join("INFO_UF2.TXT").is_file() {
+                    println!("Found pico uf2 disk {}", &mount.to_string_lossy());
+                    pico_drive = Some(mount.to_owned());
+                    break;
+                }
             }
         }
 


### PR DESCRIPTION
Much simpler fix/workaround for ChromeOS.

The issue on ChromeOS is that external USB disks are mounted into /mnt/external/DISKNAME in Linux (Crostini), while elf2uf2-rs only checks /mnt/chromeos and /mnt/external but not /mnt/external/RPI-RP2

Instead of having a manual switch as I had before, it's actually much easier to simply check for the /mnt/external/RPI-RP2 directory to exist: if it does, use that directory for uploading the UF2 file.
While the code does not check for the INFO_UF2.TXT file, it uses the hard-coded volume name instead.

Thus my other pull request [Make elf2uf2-rs work on Crostini](https://github.com/JoNil/elf2uf2-rs/pull/34#top)
