### PR TITLE
Fix critical typo

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -312,7 +312,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         let port = port.clone();
                         move || {
                             let mut port = port.lock().unwrap();
-                            port.write_all(b"elf2uf2-term\n\r").ok();
+                            port.write_all(b"elf2uf2-term\r\n").ok();
                             port.flush().ok();
                             process::exit(0);
                         }


### PR DESCRIPTION
Thank you for taking the time to review this!

I made the pull request to add a termination signal a while back. I was implementing something for embassy when I just realized that I had written `\n\r` instead of the correct `\r\n`. This is extremely counter-intuitive and possibly breaks formatting in some terminals. Before possible adoption elsewhere, I recommend changing it.