### PR TITLE
Allow the GNU ABI

### DIFF
--- a/src/elf.rs
+++ b/src/elf.rs
@@ -70,7 +70,7 @@ impl Elf32Header {
         if eh.eh_size != mem::size_of::<Elf32Header>().assert_into() {
             return Err("Invalid ELF32 format".into());
         }
-        if eh.common.abi != 0 {
+        if eh.common.abi != 0 && eh.common.abi != 3 {
             return Err("Unrecognized ABI".into());
         }
 


### PR DESCRIPTION
Per the discussion in #40, newer versions of the rust compiler have started identifying the OS/ABI version for `thumbv6-none-eabi` as GNU. This has broken elf2uf2-rs as this only accepts `none` currently.

I personally don't know enough to say with confidence that they're actually ABI compatible for the purposes of elf2uf2, but the original picotool notes:

```
Compilers may set the OS/ABI field to ELFOSABI_GNU when they use GNU
features, such as the SHF_GNU_RETAIN section flag, but the binary is
still compatible.
```

I have tested and validated this change with my pi pico w, and it appears to be working just fine.